### PR TITLE
Add to calendar btn, favicon update and event location fix [WD-5131]

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
   <title>{% block title%}Canonical Masterclasses{% endblock %}</title>
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
+  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" type="image/x-icon" />
 </head>
 
 <body>

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -52,6 +52,14 @@
                   <li class="p-media-object__meta-list-item--date">
                     <span class="u-off-screen">Date: </span>{{ session.Date.Formatted }}
                   </li>
+                  <!-- Add to calendar button, URL documentation: https://github.com/InteractionDesignFoundation/add-event-to-calendar-docs/blob/main/services/google.md -->
+                  <!-- Currently, all events start at 11AM CST with duration of 45 minutes -->
+                  <li class="p-media-object__meta-list-item--date">
+                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Masterclass:+{{ session.Topic }}&dates={{ session.Date.Calendar }}T110000/{{ session.Date.Calendar }}T114500&ctz=Europe/Paris&location={{ session.Event }}&details={{ session.Owner }}+would+like+to+talk+about+{{ session.Topic }}.%0ANotes:+{{ session.Notes }}"
+                      target="_blank" rel="noopener noreferrer">
+                      Add to Google Calendar
+                    </a>
+                  </li>
                   <li class="p-media-object__meta-list-item--location">
                     <span class="u-off-screen">Location: </span><a href="{{ session.Event }}">Google Meet</a>
                   </li>

--- a/webapp/masterclasses.py
+++ b/webapp/masterclasses.py
@@ -17,13 +17,13 @@ def get_value_row(row, type):
     if row:
         if type == datetime:
             if "formattedValue" in row:
+                parsed_datetime = datetime.strptime(
+                    row["formattedValue"], "%d %B %Y"
+                )
                 return {
-                    "Formatted": datetime.strptime(
-                        row["formattedValue"], "%d %B %Y"
-                    ).strftime("%d %b %Y"),
-                    "Object": datetime.strptime(
-                        row["formattedValue"], "%d %B %Y"
-                    ),
+                    "Formatted": parsed_datetime.strftime("%d %b %Y"),
+                    "Object": parsed_datetime,
+                    "Calendar": parsed_datetime.strftime('%Y%m%d'),
                 }
         elif "userEnteredValue" in row:
             if "stringValue" in row["userEnteredValue"]:
@@ -81,7 +81,7 @@ def get_upcoming_sessions():
         flask.abort(500, str(error))
 
     SHEET = "Upcoming"
-    RANGE = "A2:E1000"
+    RANGE = "A2:F1000"
     COLUMNS = [
         ("Topic", str),
         ("Owner", str),


### PR DESCRIPTION
Assumption: All events start at 11 AM CET with default duration of 45 mins
Reasoning: For the sake of simplicity and because currently we don't have any "Start Time" field in the [spreadsheet](https://docs.google.com/spreadsheets/d/1fFumFWIM3oHwLr9pcBlaANcadAU0bNJxbkfGKwC_1pg/).

Possible improvements:
Replace "Date" field with "DateTime" field in the spreadsheet. This will break some internal functions that use the "Date" field to fetch previous sessions. 
