### PR TITLE
Fetch thumbs from thumbnails column

### DIFF
--- a/templates/shared/_card--masterclass.html
+++ b/templates/shared/_card--masterclass.html
@@ -1,7 +1,11 @@
 <div class="p-card u-no-padding" data-tags="{{ session.Tags }}">
   {% if session.Link %}
   <a href="{{ session.Recording }}" aria-hidden="true" tabindex="-1">
+    {% if session.Thumbnails %}
+    <img class="p-card__image" alt="{{ session.Topic }} video" src="{{ session.Thumbnails }}">
+    {% else %}
     <img class="p-card__image" alt="{{ session.Topic }} video" src="https://lh3.google.com/u/0/d/{{ session.Link }}=k">
+    {% endif %}
   </a>
   <div class="p-card__inner">
     <h3 class="p-heading--5 u-no-margin--bottom"><a href="{{ session.Recording }}">{{ session.Topic }}</a></h3>

--- a/webapp/masterclasses.py
+++ b/webapp/masterclasses.py
@@ -123,7 +123,7 @@ def get_previous_sessions():
         flask.abort(500, str(error))
 
     SHEET = "Completed"
-    RANGE = "A2:I1000"
+    RANGE = "A2:J1000"
     COLUMNS = [
         ("Topic", str),
         ("Owner", str),
@@ -134,6 +134,7 @@ def get_previous_sessions():
         ("Description", str),
         ("Chat log", str),
         ("Tags", str),
+        ("Thumbnails", str)
     ]
     res = sheet.get(
         spreadsheetId=SPREADSHEET_ID,


### PR DESCRIPTION
Introduced new "thumbnails" column in the spreadsheet which has the redesigned thumbnails uploaded on the assets.ubuntu.com CDN.

This PR fetches that thumbnails column and displays that if defined, otherwise displays the gdrive one.

The new thumbnail design looks like this:
![](https://assets.ubuntu.com/v1/bc16d30d-Masterclasses%20thumbnail%20(1).jpg)