### PR TITLE
Use gcal published events and removed location

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -8,8 +8,7 @@
       <h1 class="">Masterclasses</h1>
       <p class="p-muted-heading">Watch all the talks brought to you by the Canonical team</p>
       <p>
-        <a href="https://forms.gle/gRGH1xPZmUwq9mcX9"
-          class="p-button u-no-margin--bottom">
+        <a href="https://forms.gle/gRGH1xPZmUwq9mcX9" class="p-button u-no-margin--bottom">
           Register your session
         </a>
       </p>
@@ -52,16 +51,11 @@
                   <li class="p-media-object__meta-list-item--date">
                     <span class="u-off-screen">Date: </span>{{ session.Date.Formatted }}
                   </li>
-                  <!-- Add to calendar button, URL documentation: https://github.com/InteractionDesignFoundation/add-event-to-calendar-docs/blob/main/services/google.md -->
-                  <!-- Currently, all events start at 11AM CST with duration of 45 minutes -->
+                  <!-- Add to calendar btn uses a gcal published event https://support.google.com/calendar/answer/41207 -->
                   <li class="p-media-object__meta-list-item--date">
-                    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Masterclass:+{{ session.Topic }}&dates={{ session.Date.Calendar }}T110000/{{ session.Date.Calendar }}T114500&ctz=Europe/Paris&location={{ session.Event }}&details={{ session.Owner }}+would+like+to+talk+about+{{ session.Topic }}.%0ANotes:+{{ session.Notes }}"
-                      target="_blank" rel="noopener noreferrer">
+                    <a href="{{ session.Event }}" target="_blank" rel="noopener noreferrer">
                       Add to Google Calendar
                     </a>
-                  </li>
-                  <li class="p-media-object__meta-list-item--location">
-                    <span class="u-off-screen">Location: </span><a href="{{ session.Event }}">Google Meet</a>
                   </li>
                   {% else %}
                   <li class="p-media-object__meta-list-item--date">


### PR DESCRIPTION
Now we publish events in [masterclasses calendar](https://calendar.google.com/calendar/u/0?cid=Y19iNjdjNzE1M2MzMzA4ZDM5Y2RjNzg2YjBjOWMzMDExNWY3MDg2YTc0NjQ0ZTYxYTFlZDFkYmJiYTdlOTc3YzAwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20) (only accessible inside Canonical) in favour of getting rid of the "invite-list". 

Also removed the "Location" bullet point in the upcoming sessions column, because the published event already contains google meet link.

The rationale behind using published events, is that anyone from Canonical can now record the meeting. Helps in case librarian is ooo.