### PR TITLE
Show reset btn only when topic chip clicked

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -106,6 +106,8 @@
     }
   });
 
+  let reset = document.getElementById("reset-btn");
+  reset.style.display = "none";
 
   Array.from(document.getElementsByClassName("p-chip")).forEach((el) => el.addEventListener("click", function () {
     // change class of clicked element to p-chip--positive
@@ -123,7 +125,6 @@
     });
 
     // Create a reset button, when p-chip is clicked
-    let reset = document.getElementById("reset-btn");
     reset.style.display = "block";
     reset.addEventListener("click", function () {
       // change class of clicked element to p-chip


### PR DESCRIPTION
# Done

Reset button only needs to appear when a topic filter chip is clicked. Currently, there was a bug where it used to show up even when no filter was chosen.