### PR TITLE
Make Register your session btn primary btn

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -8,7 +8,7 @@
       <h1 class="">Masterclasses</h1>
       <p class="p-muted-heading">Watch all the talks brought to you by the Canonical team</p>
       <p>
-        <a href="https://forms.gle/gRGH1xPZmUwq9mcX9" class="p-button u-no-margin--bottom">
+        <a href="https://forms.gle/gRGH1xPZmUwq9mcX9" class="p-button--positive u-no-margin--bottom">
           Register your session
         </a>
       </p>


### PR DESCRIPTION
# Done
Made the "Register your session" button a primary green button, to make it more prominent on the page.

# Screenshot
![image](https://github.com/canonical/masterclasses.canonical.com/assets/54525904/0f25c6d4-aa50-4063-955e-ee98a15d8c4c)
