### PR TITLE
WD-7722 - Add sprint presentations tab

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -16,7 +16,23 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow u-no-padding--bottom is-bordered">
+<section class="p-strip u-no-padding--bottom u-no-padding--top">
+  <div class="row">
+    <div class="p-tabs">
+      <div class="p-tabs__list" role="tablist" aria-label="Juju technology">
+        <div class="p-tabs__item">
+          <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="masterclasses-tab" id="masterclasses">Masterclasses</button>
+        </div>
+        <div class="p-tabs__item">
+          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="sprint-tab" id="sprint" tabindex="-1">Sprint presentations</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div tabindex="0" role="tabpanel" id="masterclasses-tab" aria-labelledby="masterclasses">
+<section class="p-strip is-shallow u-no-padding--bottom is-bordered" id="masterclasses">
   <div class="row">
     <div class="p-divider u-no-margin--bottom">
       <div class="col-3 p-divider__block">
@@ -86,6 +102,27 @@
     </div>
   </div>
 </section>
+</div>
+
+
+<div tabindex="0" role="tabpanel" id="sprints-tab" aria-labelledby="sprints">
+<section class="p-strip is-shallow u-no-padding--bottom is-bordered">
+  <div class="row">
+    <div class="p-divider u-no-margin--bottom">
+        <div class="row">
+          <div class="u-equal-height">
+            {% for session in sprint_sessions %}
+            {% with session=session %}
+            {% include "shared/_card--masterclass.html" %}
+            {% endwith %}
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</div>
 
 <section class="p-strip--light is-shallow is-bordered">
   <div class="row">
@@ -102,6 +139,108 @@
     </div>
   </div>
 </section>
+
+<script defer>
+(function () {
+  var keys = {
+    left: 'ArrowLeft',
+    right: 'ArrowRight',
+  };
+
+  var direction = {
+    ArrowLeft: -1,
+    ArrowRight: 1,
+  };
+
+  /**
+    Attaches a number of events that each trigger
+    the reveal of the chosen tab content
+    @param {Array} tabs an array of tabs within a container
+  */
+  function attachEvents(tabs) {
+    tabs.forEach(function (tab, index) {
+      tab.addEventListener('keyup', function (e) {
+        if (e.code === keys.left || e.code === keys.right) {
+          switchTabOnArrowPress(e, tabs);
+        }
+      });
+
+      tab.addEventListener('click', function (e) {
+        e.preventDefault();
+        setActiveTab(tab, tabs);
+      });
+
+      tab.addEventListener('focus', function () {
+        setActiveTab(tab, tabs);
+      });
+
+      tab.index = index;
+    });
+  }
+
+  /**
+    Determine which tab to show when an arrow key is pressed
+    @param {KeyboardEvent} event
+    @param {Array} tabs an array of tabs within a container
+  */
+  function switchTabOnArrowPress(event, tabs) {
+    var pressed = event.code;
+
+    if (direction[pressed]) {
+      var target = event.target;
+      if (target.index !== undefined) {
+        if (tabs[target.index + direction[pressed]]) {
+          tabs[target.index + direction[pressed]].focus();
+        } else if (pressed === keys.left) {
+          tabs[tabs.length - 1].focus();
+        } else if (pressed === keys.right) {
+          tabs[0].focus();
+        }
+      }
+    }
+  }
+
+  /**
+    Cycles through an array of tab elements and ensures
+    only the target tab and its content are selected
+    @param {HTMLElement} tab the tab whose content will be shown
+    @param {Array} tabs an array of tabs within a container
+  */
+  function setActiveTab(tab, tabs) {
+    tabs.forEach(function (tabElement) {
+      var tabContent = document.getElementById(tabElement.getAttribute('aria-controls'));
+
+      if (tabElement === tab) {
+        tabElement.setAttribute('aria-selected', true);
+        tabContent.removeAttribute('hidden');
+      } else {
+        tabElement.setAttribute('aria-selected', false);
+        tabContent.setAttribute('hidden', true);
+      }
+    });
+  }
+
+  /**
+    Attaches events to tab links within a given parent element,
+    and sets the active tab if the current hash matches the id
+    of an element controlled by a tab link
+    @param {String} selector class name of the element
+    containing the tabs we want to attach events to
+  */
+  function initTabs(selector) {
+    var tabContainers = [].slice.call(document.querySelectorAll(selector));
+
+    tabContainers.forEach(function (tabContainer) {
+      var tabs = [].slice.call(tabContainer.querySelectorAll('[aria-controls]'));
+      attachEvents(tabs);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initTabs('[role="tablist"]');
+  });
+})();
+</script>
 
 <script defer>
   let images = document.querySelectorAll('.p-card__image');

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -19,7 +19,7 @@
 <section class="p-strip u-no-padding--bottom u-no-padding--top">
   <div class="row">
     <div class="p-tabs">
-      <div class="p-tabs__list" role="tablist" aria-label="Juju technology">
+      <div class="p-tabs__list" role="tablist">
         <div class="p-tabs__item">
           <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="masterclasses-tab" id="masterclasses">Masterclasses</button>
         </div>


### PR DESCRIPTION
## Done

- Add sprint presentations tab
- Load the sessions from the spreadsheet

Closes #36 

## QA
1. Load the demo or run this branch locally
2. See there is a new tab for sprint presentations
3. Click it, and see it replaces the content below with the only video in the sheet so far 

Fixes WD-7722