### PR TITLE
Add Google Analytics tag [WD-8163]

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,15 @@
 
 <html>
 <head>
+    <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8GBDZE0HME"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-8GBDZE0HME');
+  </script>
   <title>{% block title%}Canonical Masterclasses{% endblock %}</title>
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
# Done

* Added GA4 for measuring basic ways how users interact with the website.
* Created a new property under Canonical Ltd. organisation.
* Measurement ID: G-8GBDZE0HME

Followed this article for setting up GA: https://support.google.com/analytics/answer/9304153?hl=en

## QA

> Following steps can only be done after the website is live to check if GA is working as expected.

1. Sign in to your [Google Analytics account](https://analytics.google.com/).
2. Click [Admin](https://support.google.com/analytics/answer/6132368).
3. At the top of the Property column, select masterclasses.canonical.com.
4. In the Property column, click Data streams > Web.
5. Click the data stream for Masterclasses.
6. Under Google tag, click View tag instructions.
7. On the Installation instructions page, select Install manually and then under "Test your website (optional)" click "Test".

<img width="1119" alt="Screenshot 2024-01-24 at 5 14 22 PM" src="https://github.com/canonical/masterclasses.canonical.com/assets/54525904/d8f12095-9721-4c80-a6c4-e0da17fb83e2">

