### PR TITLE
fix(upcoming-sessions): Hide when no upcoming sessions

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -35,6 +35,7 @@
 <section class="p-strip is-shallow u-no-padding--bottom is-bordered" id="masterclasses">
   <div class="row">
     <div class="p-divider u-no-margin--bottom">
+      {% if upcoming_sessions %}
       <div class="col-3 p-divider__block">
         <h2 class="p-heading--3">Upcoming sessions</h2>
         <ul class="p-list--divided">
@@ -71,6 +72,9 @@
         </ul>
       </div>
       <div class="col-9 p-divider__block">
+      {% else %}
+      <div class="col-12 p-divider__block">
+      {% endif %}
         <div class="row">
           <form class="p-search-box">
             <label class="u-off-screen" for="search-input">Search</label>


### PR DESCRIPTION
# Done
- Fix empty upcoming sessions column showing up.
- If no upcoming_sessions, main content takes the full grid space, i.e col-12 instead of col-9.

## Screenshot

![image](https://github.com/canonical/masterclasses.canonical.com/assets/54525904/4cd3be69-332b-48e5-831a-cbc2199cc681)
