### PR TITLE
Explicitly define domain and tls k8s names

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -33,6 +33,8 @@ staging:
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
+  tlsName: staging-masterclasses-canonical-com
+  domain: staging.masterclasses.canonical.com
 
 # Overrides for demo
 demo:


### PR DESCRIPTION
## Done
- Explicitly added `domain` and `tlsName` k8s ingress variables due to the unusual nature of the staging domain, `https://staging.masterclasses.canonical.com`, which is broken in `konf`

## QA
- Check that the staging sites is accessible
