### PR TITLE
Add new Admin UI with access control [WD-10569]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-OpenID==1.3.0
 alembic==1.13.1
 psycopg2-binary==2.9.6
 SQLAlchemy==2.0.25
+Flask-Admin==1.6.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,5 +1,21 @@
+import os
 import flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
 from canonicalwebteam.flask_base.app import FlaskBase
+
+from flask_admin import Admin
+from flask_admin import AdminIndexView
+from flask_admin.contrib.sqla import ModelView
+from models.PreviousSession import PreviousSession
+from models.UpcomingSession import UpcomingSession
+from models.SprintSession import SprintSession
+
+
+db_engine = create_engine(os.getenv("DATABASE_URL"))
+db_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
+)
 
 from webapp.masterclasses import masterclasses
 from webapp.sso import init_sso
@@ -16,6 +32,20 @@ app = FlaskBase(
 init_sso(app)
 
 app.register_blueprint(masterclasses, url_prefix="/")
+
+
+class RestrictedModelView(ModelView):
+    # Admin view is accesible to Web&Design team
+    def is_accessible(self):
+        return os.getenv("OPENID_LAUNCHPAD_TEAM") == "canonical-content-people"
+
+
+admin = Admin(app)
+admin.add_views(
+    RestrictedModelView(PreviousSession, db_session),
+    RestrictedModelView(UpcomingSession, db_session),
+    RestrictedModelView(SprintSession, db_session),
+)
 
 
 @app.route("/")


### PR DESCRIPTION
# Done

* Added new Admin UI, accessible from `/admin` route.
* Functional with all the models already imported and can perform all the CRUD operations.

# Note

* Admin UI is accessible by all members with `canonical-content-people` team in LP. That is everyone in Web&Design team.

# Specification


[WD-10569](https://warthogs.atlassian.net/browse/WD-10569)

[WD-10569]: https://warthogs.atlassian.net/browse/WD-10569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ