### PR TITLE
Add link icon to slide link

### DIFF
--- a/templates/shared/_card--masterclass.html
+++ b/templates/shared/_card--masterclass.html
@@ -9,6 +9,11 @@
     {% if session.description %}
     <p>{{ session.description }}</p>
     {% endif %}
+    {% if session.slides %}
+    <a href="{{ session.slides }}" target="_blank">Slides
+    <i class="p-icon--external-link"></i>
+    </a>
+    {% endif %}
     {% if session.tags %}
     <p class="u-text--muted u-no-margin--bottom">{{ session.tags }}</p>
     {% endif %}


### PR DESCRIPTION
# Done
- Add vanilla external link icon to slide for better visibility 
- Also makes it easier differentiating from the card title and slide link.