### PR TITLE
fix(jenkins) Update tlsName for staging in site.yaml

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -33,7 +33,7 @@ staging:
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect";
-  tlsName: staging-masterclasses-canonical-com
+  tlsName: staging-masterclasses-canonical-com-tls
   domain: staging.masterclasses.canonical.com
 
 # Overrides for demo


### PR DESCRIPTION
# Done

- The site.yaml contained wrong value for tlsName. Checked the secret in staging k8s cluster and updated it with the correct one.