### PR TITLE
Added back markdown text area to flask_admin view.

### DIFF
--- a/webapp/admin.py
+++ b/webapp/admin.py
@@ -727,6 +727,12 @@ class VideoModelView(RestrictedModelView):
             }
         )
         
+        # Add markdown support for description
+        form_class.description = TextAreaField(
+            'Description',
+            widget=MarkdownTextArea(),
+        )
+        
         # Configure presenters field with dynamic choices
         form_class.presenters = SelectMultipleField(
             'Presenters',


### PR DESCRIPTION
Unsure when, but I removed the text area when testing and never added it back. This merge changes the text area of the flask admin video descriptions to allow for easier multiline MD editing.