### PR TITLE
Silence sass warnings from Vanilla

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "yarn run build && yarn run serve",
     "build": "yarn run build-css",
     "lint": "yarn run lint-scss && yarn run lint-python && yarn run lint-templates",
-    "build-css": "sass src:static/css --load-path=node_modules --style=compressed && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",
+    "build-css": "sass --quiet-deps --silence-deprecation=import src:static/css --load-path=node_modules --style=compressed && postcss --use autoprefixer --replace 'static/css/**/*.css' --no-map",
     "watch-css": "yarn build-css && sass --load-path=node_modules -w src:static/css --style=compressed",
     "lint-scss": "stylelint 'src/**/*.scss'",
     "format-scss": "stylelint --fix 'src/**/*.scss'",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,12 +1,9 @@
 @import "vanilla-framework";
 @include vanilla;
 
-// Import icons from vanilla-framework
-@import "vanilla-framework/scss/patterns_icons";
-@include vf-p-icons-common;
+// Import additional icons from vanilla-framework
 @include vf-p-icon-notifications;
 @include vf-p-icon-video-play;
-@include vf-p-icon-user;
 @include vf-p-icon-tag;
 @include vf-p-icon-revisions;
 @include vf-p-icon-file;


### PR DESCRIPTION
## Done

- silences unnecessary sass warnings from Vanilla codebase
- drive-by: removes unnecessary icon imports

## QA

- Check out this feature branch
- Run command `dotrun build-css`
- There should be no warnings from sass build in the output
- Or check the [CI output](https://github.com/canonical/masterclasses.canonical.com/actions/runs/14034117293/job/39288101610?pr=73#step:7:347)
