### PR TITLE
Base template improvements

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8GBDZE0HME"></script>
   <script>
@@ -12,17 +13,14 @@
     gtag('config', 'G-8GBDZE0HME');
   </script>
   <title>Canonical Masterclass</title>
-  <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}" />
   <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" type="image/x-icon" />
 </head>
 
-<body>
-  <main class="p-content">
-
-    <header id="navigation" class="p-navigation--sliding is-dark">
-      <div class="p-navigation__row--25-75">
-        <div class="p-navigation__banner">
+<body class="l-site is-paper">
+  <header id="navigation" class="p-navigation is-dark">
+    <div class="p-navigation__row--25-75">
+      <div class="p-navigation__banner">
           <div class="p-navigation__tagged-logo">
             <a class="p-navigation__link" href="/">
               <div class="p-navigation__logo-tag">
@@ -37,7 +35,7 @@
             </li>
           </ul>
         </div>
-    
+
         <nav class="p-navigation__nav" id="main-nav">
           <ul class="p-navigation__items js-dropdown-nav-list js-navigation-sliding-panel">
             <li class="p-navigation__item">
@@ -60,15 +58,13 @@
           </ul>
         </nav>
       </div>
-    </header>
+  </header>
 
-
-
+  <main class="p-content">
     {% block content %}{% endblock %}
-
   </main>
-  
-  <footer class="p-strip is-shallow is-highlighted">
+
+  <footer class="l-footer--sticky p-strip is-dark is-shallow">
     <div class="row">
       <div class="col-12">
         ©  Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.
@@ -92,278 +88,61 @@
 </html>
 
 <script>
-  const initNavigationSliding = () => {
-    const ANIMATION_SNAP_DURATION = 100;
-    const navigation = document.querySelector('.p-navigation--sliding, .p-navigation--reduced');
-    const secondaryNavigation = document.querySelector('.p-navigation--reduced + .p-navigation');
-    const toggles = document.querySelectorAll('.p-navigation__nav .p-navigation__link[aria-controls]:not(.js-back-button)');
-    const searchButtons = document.querySelectorAll('.js-search-button');
-    const menuButton = document.querySelector('.js-menu-button');
-    const dropdownNavLists = document.querySelectorAll('.js-dropdown-nav-list');
-    const topNavList = [...dropdownNavLists].filter((list) => !list.parentNode.closest('.js-dropdown-nav-list'))[0];
-  
-    const hasSearch = searchButtons.length > 0;
-  
-    const closeAllDropdowns = () => {
-      if (hasSearch) {
-        closeSearch();
+  function initNavigation(element) {
+    const menuButton = element.querySelector('.js-menu-button');
+    if (menuButton) {
+      menuButton.addEventListener('click', toggleMenu);
+    }
+
+    function toggleMenu(e) {
+      e.preventDefault();
+
+      var navigation = e.target.closest('.p-navigation');
+      if (navigation.classList.contains('has-menu-open')) {
+        closeMenu();
+      } else {
+        closeMenu();
+        openMenu(e);
       }
-      resetToggles();
-      navigation.classList.remove('has-menu-open');
-      if (secondaryNavigation) {
-        secondaryNavigation.classList.remove('has-menu-open');
-      }
-      menuButton.innerHTML = 'Menu';
-    };
-  
-    const keyPressHandler = (e) => {
-      if (e.key === 'Escape') {
-        closeAllDropdowns();
-      }
-    };
-  
-    const closeSearch = () => {
-      searchButtons.forEach((searchButton) => {
+    }
+
+    function openMenu(e) {
+      e.preventDefault();
+      var navigation = e.target.closest('.p-navigation');
+      var nav = navigation.querySelector('.p-navigation__nav');
+
+      var buttons = document.querySelectorAll('.js-menu-button');
+
+      buttons.forEach((searchButton) => {
+        searchButton.setAttribute('aria-pressed', true);
+      });
+
+      navigation.classList.add('has-menu-open');
+      document.addEventListener('keyup', keyPressHandler);
+    }
+
+    function closeMenu() {
+      var navigation = document.querySelector('.p-navigation');
+      var nav = navigation.querySelector('.p-navigation__nav');
+
+      var banner = document.querySelector('.p-navigation__banner');
+      var buttons = document.querySelectorAll('.js-menu-button');
+
+      buttons.forEach((searchButton) => {
         searchButton.removeAttribute('aria-pressed');
       });
-  
-      navigation.classList.remove('has-search-open');
+
+      navigation.classList.remove('has-menu-open');
       document.removeEventListener('keyup', keyPressHandler);
-    };
-  
-    menuButton.addEventListener('click', function(e) {
-      e.preventDefault();
-      closeSearch();
-      if (navigation.classList.contains('has-menu-open')) {
-        closeAllDropdowns();
-      } else {
-        navigation.classList.add('has-menu-open');
-        e.target.innerHTML = 'Close menu';
-        setFocusable(topNavList);
-      }
-    });
-  
-    const secondaryNavToggle = document.querySelector('.js-secondary-menu-toggle-button');
-    if (secondaryNavToggle) {
-      secondaryNavToggle.addEventListener('click', (event) => {
-        event.preventDefault();
-        closeSearch();
-        if (secondaryNavigation.classList.contains('has-menu-open')) {
-          closeAllDropdowns();
-        } else {
-          secondaryNavigation.classList.add('has-menu-open');
-        }
-      });
     }
-  
-    const resetToggles = (exception) => {
-      toggles.forEach(function(toggle) {
-        const target = document.getElementById(toggle.getAttribute('aria-controls'));
-        if (!target || target === exception) {
-          return;
-        }
-        collapseDropdown(toggle, target);
-      });
-    };
-  
-    const setActiveDropdown = (dropdownToggleButton, isActive = true) => {
-      // set active state of the dropdown toggle (to slide the panel into view)
-      const dropdownToggleEl = dropdownToggleButton.closest('.js-navigation-dropdown-toggle');
-      dropdownToggleEl?.classList.toggle('is-active', isActive);
-  
-      // set active state of the parent dropdown panel (to fade it out of view)
-      const parentLevelDropdown = dropdownToggleEl.closest('.js-navigation-sliding-panel');
-      parentLevelDropdown?.classList.toggle('is-active', isActive);
-    };
-  
-    const collapseDropdown = (dropdownToggleButton, targetDropdown, animated = false) => {
-      const closeHandler = () => {
-        targetDropdown.setAttribute('aria-hidden', 'true');
-        setActiveDropdown(dropdownToggleButton, false);
-      };
-  
-      targetDropdown.classList.add('is-collapsed');
-      if (animated) {
-        setTimeout(closeHandler, ANIMATION_SNAP_DURATION);
-      } else {
-        closeHandler();
+
+    function keyPressHandler(e) {
+      if (e.key === 'Escape') {
+        closeMenu();
       }
-    };
-  
-    const expandDropdown = (dropdownToggleButton, targetDropdown, animated = false) => {
-      setActiveDropdown(dropdownToggleButton);
-      targetDropdown.setAttribute('aria-hidden', 'false');
-  
-      if (animated) {
-        // trigger the CSS transition
-        requestAnimationFrame(() => {
-          targetDropdown.classList.remove('is-collapsed');
-        });
-      } else {
-        // make it appear immediately
-        targetDropdown.classList.remove('is-collapsed');
-      }
-  
-      setFocusable(targetDropdown);
-    };
-  
-    // when clicking outside navigation, close all dropdowns
-    document.addEventListener('click', function(event) {
-      const target = event.target;
-      if (target.closest) {
-        if (!target.closest('.p-navigation, .p-navigation--sliding, .p-navigation--reduced')) {
-          closeAllDropdowns();
-        }
-      }
-    });
-  
-    const setListFocusable = (list) => {
-      // turn on focusability for all direct children in the target dropdown
-      if (list) {
-        for (const item of list.children) {
-          item.children[0].setAttribute('tabindex', '0');
-        }
-      }
-    };
-  
-    const setFocusable = (target) => {
-      // turn off focusability for all dropdown lists in the navigation
-      dropdownNavLists.forEach(function(list) {
-        if (list != topNavList) {
-          const elements = list.querySelectorAll('ul > li > a, ul > li > button');
-          elements.forEach(function(element) {
-            element.setAttribute('tabindex', '-1');
-          });
-        }
-      });
-  
-      // if target dropdown is not a list, find the list in it
-      const isList = target.classList.contains('js-dropdown-nav-list');
-      if (!isList) {
-        // find all lists in the target dropdown and make them focusable
-        target.querySelectorAll('.js-dropdown-nav-list').forEach(function(element) {
-          setListFocusable(element);
-        });
-      } else {
-        setListFocusable(target);
-      }
-    };
-  
-    toggles.forEach(function(toggle) {
-      toggle.addEventListener('click', function(e) {
-        e.preventDefault();
-        closeSearch();
-        const target = document.getElementById(toggle.getAttribute('aria-controls'));
-        if (target) {
-          // check if the toggled dropdown is child of another dropdown
-          const isNested = !!target.parentNode.closest('.p-navigation__dropdown');
-          if (!isNested) {
-            resetToggles(target);
-          }
-  
-          if (target.getAttribute('aria-hidden') === 'true') {
-            // only animate the dropdown if menu is not open, otherwise just switch the visible one
-            expandDropdown(toggle, target, !navigation.classList.contains('has-menu-open'));
-            navigation.classList.add('has-menu-open');
-          } else {
-            collapseDropdown(toggle, target, true);
-            navigation.classList.remove('has-menu-open');
-          }
-        }
-      });
-    });
-  
-    const goBackOneLevel = (e, backButton) => {
-      e.preventDefault();
-      const target = backButton.closest('.p-navigation__dropdown');
-      target.setAttribute('aria-hidden', 'true');
-      setActiveDropdown(backButton, false);
-      setFocusable(target.parentNode.parentNode);
-    };
-  
-    dropdownNavLists.forEach(function(dropdown) {
-      dropdown.children[1].addEventListener('keydown', function(e) {
-        if (e.shiftKey && e.key === 'Tab' && window.getComputedStyle(dropdown.children[0], null).display === 'none') {
-          goBackOneLevel(e, dropdown.children[1].children[0]);
-          dropdown.parentNode.children[0].focus({
-            preventScroll: true
-          });
-        }
-      });
-    });
-  
-    document.querySelectorAll('.js-back-button').forEach(function(backButton) {
-      backButton.addEventListener('click', function(e) {
-        goBackOneLevel(e, backButton);
-      });
-    });
-  
-    if (hasSearch) {
-      const toggleSearch = (e) => {
-        e.preventDefault();
-  
-        if (navigation.classList.contains('has-search-open')) {
-          closeAllDropdowns();
-        } else {
-          closeAllDropdowns();
-          openSearch(e);
-        }
-      };
-  
-      searchButtons.forEach((searchButton) => {
-        searchButton.addEventListener('click', toggleSearch);
-      });
-  
-      const overlay = document.querySelector('.p-navigation__search-overlay');
-      if (overlay) {
-        overlay.addEventListener('click', closeAllDropdowns);
-      }
-  
-      const openSearch = (e) => {
-        e.preventDefault();
-  
-        var searchInput = navigation.querySelector('.p-search-box__input');
-        if (!searchInput) {
-          searchInput = secondaryNavigation.querySelector('.p-search-box__input');
-        }
-        var buttons = document.querySelectorAll('.js-search-button');
-  
-        buttons.forEach((searchButton) => {
-          searchButton.setAttribute('aria-pressed', true);
-        });
-  
-        navigation.classList.add('has-search-open');
-        searchInput.focus();
-        document.addEventListener('keyup', keyPressHandler);
-      };
     }
-  
-    // throttle util (for window resize event)
-    var throttle = function(fn, delay) {
-      var timer = null;
-      return function() {
-        var context = this,
-          args = arguments;
-        clearTimeout(timer);
-        timer = setTimeout(function() {
-          fn.apply(context, args);
-        }, delay);
-      };
-    };
-  
-    // hide side navigation drawer when screen is resized horizontally
-    let previousWidth = window.innerWidth;
-    window.addEventListener(
-      'resize',
-      throttle(function() {
-        const currentWidth = window.innerWidth;
-        if (currentWidth !== previousWidth) {
-          closeAllDropdowns();
-          previousWidth = currentWidth;
-        }
-      }, 10),
-    );
-  };
-  
-  initNavigationSliding();
+  }
+
+  var navigation = document.querySelector('#navigation');
+  initNavigation(navigation);
 </script>

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -72,11 +72,11 @@
       <h3 class="p-muted-heading u-sv2">Something missing?</h3>
       <p class="p-heading--3">If you would like to see a topic covered but you don't have the knowledge, submit an idea
         to the team.</p>
-      <p>
-        <a href="https://discourse.canonical.com/c/masterclasses/suggested-ideas/79" class="p-button u-no-margin--bottom">
-          Register an idea
-        </a>
-      </p>
+
+      <a href="/register" class="p-button u-no-margin--bottom">
+        Register an idea
+      </a>
+
     </div>
   </div>
 </section>

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -13,20 +13,20 @@
       </div>
       <div class="p-section--shallow">
         <p>
-          All our internal talks are recorded and made available here for you to watch at your leisure. 
-          From product deep dives to technical talks, we've got you covered. Curated by the events team, 
-          these sessions cover everything from Ubuntu and cloud infrastructure to marketing and leadership. 
+          All our internal talks are recorded and made available here for you to watch at your leisure.
+          From product deep dives to technical talks, we've got you covered. Curated by the events team,
+          these sessions cover everything from Ubuntu and cloud infrastructure to marketing and leadership.
           Whether you're looking to expand your knowledge or catch up on a session you missed, you'll find valuable content here.
         </p>
       </div>
-      
+
       <a href="/videos" class="p-button--positive">Explore Catalog</a>
       <a class="p-button" id="lucky-button">I'm feeling lucky</a>
 
     </div>
     <div class="col u-align--center u-hide--medium u-hide--small u-vertically-center">
       <img src="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,h_366/https://assets.ubuntu.com/v1/3a4d4155-Training.svg"
-        srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_900,h_732/https://assets.ubuntu.com/v1/3a4d4155-Training.svg 2x" 
+        srcset="https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_900,h_732/https://assets.ubuntu.com/v1/3a4d4155-Training.svg 2x"
         alt="" width="450" height="366" loading="auto">
     </div>
   </div>
@@ -49,12 +49,12 @@
             {% set _=shown.append(1) %}
           {% endif %}
         {% endfor %}
-        
+
         {% if upcoming_videos_24h and shown|length < 2 %}
           {{ upcoming_session(upcoming_videos_24h[0], 'soon', now) }}
           {% set _=shown.append(1) %}
         {% endif %}
-        
+
         {% if upcoming_videos_future and shown|length < 2 %}
           {{ upcoming_session(upcoming_videos_future[0], 'future', now) }}
           {% set _=shown.append(1) %}
@@ -66,7 +66,7 @@
 {% endif %}
 
 
-<section class="p-strip--light is-shallow is-bordered">
+<section class="p-strip is-light">
   <div class="row">
     <div class="col-9">
       <h3 class="p-muted-heading u-sv2">Something missing?</h3>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<section class="p-strip is-bordered">
+<section class="p-strip">
   <div class="row">
     <div class="col-8">
       <h1>Register your Masterclass session</h1>
@@ -21,7 +21,7 @@
 
       <form method="POST" class="p-form">
         {{ form.csrf_token }}
-        
+
         <div class="p-form__group">
           <label class="p-form__label" for="title">Name of session *</label>
           {{ form.title(class="p-form__control") }}

--- a/templates/video_player.html
+++ b/templates/video_player.html
@@ -9,7 +9,7 @@ function togglePresenters(event) {
     event.preventDefault();
     const morePresenters = document.getElementById('more-presenters');
     const showMoreLink = document.getElementById('show-more-presenters');
-    
+
     if (morePresenters.style.display === 'none') {
         morePresenters.style.display = 'inline';
         showMoreLink.style.display = 'none';  // Hide the "..." when expanded
@@ -17,18 +17,18 @@ function togglePresenters(event) {
 }
 </script>
 
-<div class="p-strip is-shallow u-no-padding--bottom is-bordered">
+<div class="p-strip is-shallow u-no-padding--bottom">
   <div class="row">
     <div class="col-9">
-      <iframe 
-        src="https://drive.google.com/file/d/{{ video.recording|google_drive_id }}/preview" 
-        allow="autoplay" 
-        allowfullscreen 
+      <iframe
+        src="https://drive.google.com/file/d/{{ video.recording|google_drive_id }}/preview"
+        allow="autoplay"
+        allowfullscreen
         class="iframe-video"
       ></iframe>
 
       <h1 class="p-heading--2">{{ video.title }}</h1>
-      
+
       <ul class="p-inline-list u-no-margin--bottom">
         {% if video.presenters %}
         <li class="p-inline-list__item">
@@ -46,7 +46,7 @@ function togglePresenters(event) {
           </span>
         </li>
         {% endif %}
-        
+
         {% if video.unixstart %}
         <li class="p-inline-list__item">
           <span style="white-space: nowrap">

--- a/templates/videos.html
+++ b/templates/videos.html
@@ -3,7 +3,7 @@
 {% from "shared/_video_card.html" import video_card %}
 {% block content %}
 <div tabindex="0" role="tabpanel" id="masterclasses-tab" aria-labelledby="masterclasses">
-  <section class="p-strip is-shallow u-no-padding--bottom is-bordered" id="masterclasses">
+  <section class="p-strip is-shallow u-no-padding--bottom" id="masterclasses">
     <div class="row">
       <div class="p-divider u-no-margin--bottom">
         <div class="col-3">
@@ -35,7 +35,7 @@
             </form>
           </div>
 
-          <div class="u-equal-height" style="padding-bottom: 1rem;">              
+          <div class="u-equal-height" style="padding-bottom: 1rem;">
             {% for video in recorded_videos %}
             <div class="col-4">
               {{ video_card(video) }}
@@ -71,7 +71,7 @@
     // Function to update URL parameters
     function updateURLParameters() {
       const params = new URLSearchParams();
-      
+
       // Add each filter type to URL parameters
       Object.entries(filters).forEach(([key, value]) => {
         if (value instanceof Set && value.size > 0) {
@@ -89,7 +89,7 @@
     // Function to restore filters from URL parameters
     function restoreFiltersFromURL() {
       const params = new URLSearchParams(window.location.search);
-      
+
       // Restore each filter type
       params.forEach((value, key) => {
         if (key in filters) {
@@ -107,20 +107,20 @@
           }
         }
       });
-      
+
       updateVisibility();
     }
 
     function updateVisibility() {
       const container = document.querySelector('.u-equal-height');
       let visibleCount = 0;
-      
+
       videoCards.forEach(card => {
         const cardTopics = card.dataset.topics.split(' ').filter(Boolean);
         const cardEvents = card.dataset.events.split(' ').filter(Boolean);
         const cardDates = card.dataset.dates.split(' ').filter(Boolean);
         const cardPresenters = card.dataset.presenters.split(' ').filter(Boolean);
-        
+
         // Get searchable content from the card and normalize it
         const title = normalizeText(card.querySelector('.video-title').textContent);
         const tags = normalizeText([...cardTopics, ...cardEvents, ...cardDates].join(' '));
@@ -129,23 +129,23 @@
 
         // Split search terms and normalize them
         const searchTerms = normalizeText(filters.search).split(' ').filter(Boolean);
-        const searchMatch = !filters.search || 
+        const searchMatch = !filters.search ||
           searchTerms.every(term => searchContent.includes(term));
 
         // Check filters using OR logic within categories
-        const topicsMatch = filters.topic.size === 0 || 
+        const topicsMatch = filters.topic.size === 0 ||
           [...filters.topic].some(topic => cardTopics.includes(topic));
-        const eventsMatch = filters.event.size === 0 || 
+        const eventsMatch = filters.event.size === 0 ||
           [...filters.event].some(event => cardEvents.includes(event));
-        const datesMatch = filters.date.size === 0 || 
+        const datesMatch = filters.date.size === 0 ||
           [...filters.date].some(date => cardDates.includes(date));
-        const presentersMatch = filters.presenter.size === 0 || 
+        const presentersMatch = filters.presenter.size === 0 ||
           [...filters.presenter].some(presenter => cardPresenters.includes(presenter));
 
         // Show/hide card based on filters
         const isVisible = searchMatch && topicsMatch && eventsMatch && datesMatch && presentersMatch;
         const cardWrapper = card.closest('.col-4');
-        
+
         if (isVisible) {
           cardWrapper.style.display = '';
           visibleCount++;
@@ -201,7 +201,7 @@
 
     if (filterButton && filterAccordion) {
       filterButton.addEventListener('click', () => {
-        const isHidden = filterAccordion.classList.contains('u-hide--small') || 
+        const isHidden = filterAccordion.classList.contains('u-hide--small') ||
                         filterAccordion.classList.contains('u-hide--medium');
         if (isHidden) {
           filterAccordion.classList.remove('u-hide--small');
@@ -278,5 +278,5 @@
       btn.dataset.showing = isShowingLess ? 'more' : 'less';
     });
   });
-</script> 
+</script>
 {% endblock %}


### PR DESCRIPTION
## Done

- Moves `main` element to correctly wrap main content only
- Uses Vanilla site layout with sticky footer and paper background'
- Removes unnecessary usage of sliding navigation (and simplifies the JS handling of navigation on mobile)
- Doing some small changes in content templates to accommodate that (removing bordered strip)
- Drive-by: fix "Register an idea" button on home page to link to form instead of discourse

## QA

- Check home page on demo: https://masterclasses-canonical-com-74.demos.haus/
- Make sure it looks OK
- Go to small screen, make sure you can open navigation and it works as expected
- Check other views: [videos](https://masterclasses-canonical-com-74.demos.haus/videos), [video](https://masterclasses-canonical-com-74.demos.haus/videos/analytics-guide-securing-docker-design-exploring-kubernetes-devops-python-class-2), [register](https://masterclasses-canonical-com-74.demos.haus/register) to make sure they are not broken
- On home page, check "Register an idea" button at the bottom, make sure it links to form

## Issue / Card

Fixes [WD-20325](https://warthogs.atlassian.net/browse/WD-20325)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20325]: https://warthogs.atlassian.net/browse/WD-20325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ