### PR TITLE
Fix empty upcoming on home page

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -54,6 +54,7 @@
   {% set _=upcoming.append([upcoming_videos_future[0], 'future']) %}
 {% endif %}
 
+{%- if upcoming|length > 0 -%}
 {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true) -%}
 {%- if slot == 'title' -%}
 <h2>Upcoming sessions</h2>
@@ -113,6 +114,7 @@
 {%- endif -%}
 {%- endfor -%}
 {%- endcall -%}
+{%- endif -%}
 
 <section class="p-strip is-light">
   <div class="row">


### PR DESCRIPTION
## Done

- Fixes a but with heading appearing even if there are no upcoming sessions

<img width="1446" alt="image" src="https://github.com/user-attachments/assets/7dbf72e4-2173-4fef-9d10-a9caf4d85558" />


## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- Remove upcoming sessions from db or add `{% set upcoming = [] %}` in line 56 of `masterclasses.html` to fake empty data
- Go to home page and see if it renders as expected

## Screenshots

After fix:

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/12315a2f-5317-4f97-9390-f8a27f84ed6c" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
