### PR TITLE
Add recent sprints to home page

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -134,6 +134,12 @@
                 allowfullscreen
                 class="iframe-video"></iframe>
         <p>Videos from Engineering Spring in Frankfurt include the opening and closing plenary, discussion panels, workshops and lighting talks.</p>
+        <div class="p-notification--caution is-inline">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">In progress:</h5>
+            <p class="p-notification__message">Not all Frankfurt Engineering Sprint videos have been processed and uploaded yet.</p>
+          </div>
+        </div>
         <p>
           <a href="/videos?event=engineering-sprint&date=q2-2025">Explore all Frankfurt Engineering Sprint videos&nbsp;&rsaquo;</a>
         </p>

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -116,6 +116,44 @@
 {%- endcall -%}
 {%- endif -%}
 
+<div class="p-section">
+  {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=false) -%}
+    {%- if slot == 'title' -%}
+      <h2>Recent Sprints</h2>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_1' -%}
+      <h3 class="p-muted-heading">Engineering Sprint</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_1' -%}
+      <iframe src="https://drive.google.com/file/d/11hNPkDQee8croIPMOep_2Qj6zmUq7LuU/preview"
+              allow="autoplay"
+              allowfullscreen
+              class="iframe-video"></iframe>
+      <div class="p-cta-block">
+        <a href="/videos?event=engineering-sprint&date=q2-2025" class="p-button">Browse all Engineering Sprint
+        videos</a>
+      </div>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_2' -%}
+      <h3 class="p-muted-heading">Roadmap Sprint</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_2' -%}
+      <iframe src="https://drive.google.com/file/d/10RMCGtuDtwiuhEtjv6unJbYhZl04GiEa/preview"
+              allow="autoplay"
+              allowfullscreen
+              class="iframe-video"></iframe>
+      <div class="p-cta-block">
+        <a href="/videos?event=roadmap-sprint&date=q2-2025" class="p-button">Browse all Roadmap Sprint videos</a>
+      </div>
+    {%- endif -%}
+
+  {%- endcall -%}
+</div>
+
 <section class="p-strip is-light">
   <div class="row">
     <div class="col-9">

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -127,15 +127,16 @@
     {%- endif -%}
 
     {%- if slot == 'list_item_description_1' -%}
-      <iframe src="https://drive.google.com/file/d/11hNPkDQee8croIPMOep_2Qj6zmUq7LuU/preview"
-              title="Opening Plenary of the Engineering Sprint in Frankfurt, May 2025"
-              allow="autoplay"
-              allowfullscreen
-              class="iframe-video"></iframe>
-              <p>Videos from Engineering Spring in Frankfurt include the opening and closing plenary, discussion panels, workshops and lighting talks.</p>
-      <div class="p-cta-block">
-        <a href="/videos?event=engineering-sprint&date=q2-2025" class="p-button">Browse all Engineering Sprint
-        videos</a>
+      <div class="p-section--shallow">
+        <iframe src="https://drive.google.com/file/d/11hNPkDQee8croIPMOep_2Qj6zmUq7LuU/preview"
+                title="Opening Plenary of the Engineering Sprint in Frankfurt, May 2025"
+                allow="autoplay"
+                allowfullscreen
+                class="iframe-video"></iframe>
+        <p>Videos from Engineering Spring in Frankfurt include the opening and closing plenary, discussion panels, workshops and lighting talks.</p>
+        <p>
+          <a href="/videos?event=engineering-sprint&date=q2-2025">Explore all Frankfurt Engineering Sprint videos&nbsp;&rsaquo;</a>
+        </p>
       </div>
     {%- endif -%}
 
@@ -144,14 +145,16 @@
     {%- endif -%}
 
     {%- if slot == 'list_item_description_2' -%}
-      <iframe src="https://drive.google.com/file/d/10RMCGtuDtwiuhEtjv6unJbYhZl04GiEa/preview"
-              title="Opening Plenary of the Product Roadmap Sprint in Frankfurt, May 2025"
-              allow="autoplay"
-              allowfullscreen
-              class="iframe-video"></iframe>
-      <p>Videos from Product Roadmap Spring in Frankfurt include the opening and closing plenary, presentations of the product teams, discussion panels and lighting talks.</p>
-      <div class="p-cta-block">
-        <a href="/videos?event=roadmap-sprint&date=q2-2025" class="p-button">Browse all Roadmap Sprint videos</a>
+      <div class="p-section--shallow">
+        <iframe src="https://drive.google.com/file/d/10RMCGtuDtwiuhEtjv6unJbYhZl04GiEa/preview"
+                title="Opening Plenary of the Product Roadmap Sprint in Frankfurt, May 2025"
+                allow="autoplay"
+                allowfullscreen
+                class="iframe-video"></iframe>
+        <p>Videos from Product Roadmap Spring in Frankfurt include the opening and closing plenary, presentations of the product teams, discussion panels and lighting talks.</p>
+        <p>
+          <a href="/videos?event=roadmap-sprint&date=q2-2025">Explore all Frankfurt Roadmap Sprint videos&nbsp;&rsaquo;</a>
+        </p>
       </div>
     {%- endif -%}
 

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -134,12 +134,6 @@
                 allowfullscreen
                 class="iframe-video"></iframe>
         <p>Videos from Engineering Spring in Frankfurt include the opening and closing plenary, discussion panels, workshops and lighting talks.</p>
-        <div class="p-notification--caution is-inline">
-          <div class="p-notification__content">
-            <h5 class="p-notification__title">In progress:</h5>
-            <p class="p-notification__message">Not all Frankfurt Engineering Sprint videos have been processed and uploaded yet.</p>
-          </div>
-        </div>
         <p>
           <a href="/videos?event=engineering-sprint&date=q2-2025">Explore all Frankfurt Engineering Sprint videos&nbsp;&rsaquo;</a>
         </p>

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -128,9 +128,11 @@
 
     {%- if slot == 'list_item_description_1' -%}
       <iframe src="https://drive.google.com/file/d/11hNPkDQee8croIPMOep_2Qj6zmUq7LuU/preview"
+              title="Opening Plenary of the Engineering Sprint in Frankfurt, May 2025"
               allow="autoplay"
               allowfullscreen
               class="iframe-video"></iframe>
+              <p>Videos from Engineering Spring in Frankfurt include the opening and closing plenary, discussion panels, workshops and lighting talks.</p>
       <div class="p-cta-block">
         <a href="/videos?event=engineering-sprint&date=q2-2025" class="p-button">Browse all Engineering Sprint
         videos</a>
@@ -143,9 +145,11 @@
 
     {%- if slot == 'list_item_description_2' -%}
       <iframe src="https://drive.google.com/file/d/10RMCGtuDtwiuhEtjv6unJbYhZl04GiEa/preview"
+              title="Opening Plenary of the Product Roadmap Sprint in Frankfurt, May 2025"
               allow="autoplay"
               allowfullscreen
               class="iframe-video"></iframe>
+      <p>Videos from Product Roadmap Spring in Frankfurt include the opening and closing plenary, presentations of the product teams, discussion panels and lighting talks.</p>
       <div class="p-cta-block">
         <a href="/videos?event=roadmap-sprint&date=q2-2025" class="p-button">Browse all Roadmap Sprint videos</a>
       </div>


### PR DESCRIPTION
## Done

- Adds a section with recent sprints (Engineering and Roadmap) to home page.
- This is currently manually maintained

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- Open home page: https://masterclasses-canonical-com-80.demos.haus/
- Check the new "Recent Sprints" section
- Click on "Explore …" links
  - NOTE: those links will not show actual videos from sprints (we don't have them in demo server), but URL should have correct filters reflected in query params

## Issue / Card

Fixes WD-22172

## Screenshots

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/71209c1f-020a-4e1d-812c-3dddb8fd8700" />





## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
