### PR TITLE
Add Berlin Commercial Sprint to home page

### DIFF
--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -123,35 +123,63 @@
     {%- endif -%}
 
     {%- if slot == 'list_item_title_1' -%}
-      <h3 class="p-muted-heading">Engineering Sprint</h3>
+      <h3 class="p-muted-heading">Commercial Sprint</h3>
     {%- endif -%}
 
     {%- if slot == 'list_item_description_1' -%}
+      <div class="p-section--shallow">
+        <iframe src="https://drive.google.com/file/d/1TmDr0SlQGZl36xKB0bR0IL36kv0KAtle/preview"
+                title="Plenary: Leads, Commercial Sprint in Berlin, July 2025"
+                allow="autoplay"
+                allowfullscreen
+                class="iframe-video"></iframe>
+        <p>Videos from Commercial Sprint in Berlin include the plenaries, deep dives and lightning talks.</p>
+        {% set berlin_end_unixtime = 1753488000 %} {# 2025-07-26T00:00:00Z #}
+
+        {%- if now < berlin_end_unixtime -%}
+        <div class="p-notification--caution is-inline">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">In progress:</h5>
+            <p class="p-notification__message">Berlin Commercial Sprint is still in progress, videos are processed and uploaded as they become available.</p>
+          </div>
+        </div>
+        {%- endif -%}
+        <p>
+          <a href="/videos?event=commercial-sprint&date=q3-2025">Explore all Berlin Commercial Sprint videos&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_title_2' -%}
+      <h3 class="p-muted-heading">Engineering Sprint</h3>
+    {%- endif -%}
+
+    {%- if slot == 'list_item_description_2' -%}
       <div class="p-section--shallow">
         <iframe src="https://drive.google.com/file/d/11hNPkDQee8croIPMOep_2Qj6zmUq7LuU/preview"
                 title="Opening Plenary of the Engineering Sprint in Frankfurt, May 2025"
                 allow="autoplay"
                 allowfullscreen
                 class="iframe-video"></iframe>
-        <p>Videos from Engineering Spring in Frankfurt include the opening and closing plenary, discussion panels, workshops and lighting talks.</p>
+        <p>Videos from Engineering Sprint in Frankfurt include the opening and closing plenary, discussion panels, workshops and lighting talks.</p>
         <p>
           <a href="/videos?event=engineering-sprint&date=q2-2025">Explore all Frankfurt Engineering Sprint videos&nbsp;&rsaquo;</a>
         </p>
       </div>
     {%- endif -%}
 
-    {%- if slot == 'list_item_title_2' -%}
+    {%- if slot == 'list_item_title_3' -%}
       <h3 class="p-muted-heading">Roadmap Sprint</h3>
     {%- endif -%}
 
-    {%- if slot == 'list_item_description_2' -%}
+    {%- if slot == 'list_item_description_3' -%}
       <div class="p-section--shallow">
         <iframe src="https://drive.google.com/file/d/10RMCGtuDtwiuhEtjv6unJbYhZl04GiEa/preview"
                 title="Opening Plenary of the Product Roadmap Sprint in Frankfurt, May 2025"
                 allow="autoplay"
                 allowfullscreen
                 class="iframe-video"></iframe>
-        <p>Videos from Product Roadmap Spring in Frankfurt include the opening and closing plenary, presentations of the product teams, discussion panels and lighting talks.</p>
+        <p>Videos from Product Roadmap Sprint in Frankfurt include the opening and closing plenary, presentations of the product teams, discussion panels and lighting talks.</p>
         <p>
           <a href="/videos?event=roadmap-sprint&date=q2-2025">Explore all Frankfurt Roadmap Sprint videos&nbsp;&rsaquo;</a>
         </p>


### PR DESCRIPTION
## Done

Adds current Berlin Commercial sprint on the home page

## QA

Demos are failing unfortunately, so it needs to be QA'ed locally.

- Check out this feature branch
- Run the site using the command `dotrun` (see README for running database)
- View the site locally in your web browser at: http://0.0.0.0:8409/
  - Be sure to test on mobile, tablet and desktop screen sizes
- Check newly added Comercial Sprint on home page

## Screenshots

<img width="1310" height="737" alt="image" src="https://github.com/user-attachments/assets/364a00fe-364e-4c67-8bd3-271262c717fa" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
