### PR TITLE
Add 2026 Madrid sprints

### DIFF
--- a/events/engineering-sprint-madrid-2026.yaml
+++ b/events/engineering-sprint-madrid-2026.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=./event.schema.json
 title: Engineering Sprint
 subtitle: Madrid, May 2026
+live_stream_url: https://stream.meet.google.com/stream/4f77e620-f41c-4ab9-beb2-29aa1c79dfd2
 all_videos_url: /videos?event=engineering-sprint&date=q2-2026
 days:
   - date: 2026-05-11

--- a/events/engineering-sprint-madrid-2026.yaml
+++ b/events/engineering-sprint-madrid-2026.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=./event.schema.json
+title: Engineering Sprint
+subtitle: Madrid, May 2026
+all_videos_url: /videos?event=engineering-sprint&date=q2-2026
+days:
+  - date: 2026-05-11
+    title: Monday, May 11
+    sessions:
+      - title: Plenary
+        start: 2026-05-11 09:00:00
+        end: 2026-05-11 10:00:00
+      - title: Lightning talks
+        start: 2026-05-11 17:30:00
+        end: 2026-05-11 18:00:00
+  - date: 2026-05-12
+    title: Tuesday, May 12
+    sessions:
+      - title: Lightning talks (AM)
+        start: 2026-05-12 09:00:00
+        end: 2026-05-12 09:30:00
+      - title: Panel # Women's Resource Group
+        start: 2026-05-12 14:00:00
+        end: 2026-05-12 15:00:00
+      - title: Lightning talks (PM)
+        start: 2026-05-12 17:30:00
+        end: 2026-05-12 18:00:00
+  - date: 2026-05-13
+    title: Wednesday, May 13
+    sessions:
+      - title: Lightning talks (AM)
+        start: 2026-05-13 09:00:00
+        end: 2026-05-13 09:30:00
+      - title: Lightning talks (PM)
+        start: 2026-05-13 17:30:00
+        end: 2026-05-13 18:00:00
+  - date: 2026-05-14
+    title: Thursday, May 14
+    sessions:
+      - title: Lightning talks (AM)
+        start: 2026-05-14 09:00:00
+        end: 2026-05-14 09:30:00
+      - title: Knowledge sharing # Rust Unconference
+        start: 2026-05-14 14:00:00
+        end: 2026-05-14 16:00:00
+      - title: Lightning talks (PM)
+        start: 2026-05-14 17:30:00
+        end: 2026-05-14 18:00:00
+  - date: 2026-05-15
+    title: Friday, May 15
+    sessions:
+      - title: Lightning talks (AM)
+        start: 2026-05-15 09:00:00
+        end: 2026-05-15 09:30:00
+      - title: Lightning talks (PM)
+        start: 2026-05-15 15:30:00
+        end: 2026-05-15 16:00:00
+      - title: Closing plenary
+        start: 2026-05-15 16:00:00
+        end: 2026-05-15 16:30:00

--- a/events/engineering-sprint-madrid-2026.yaml
+++ b/events/engineering-sprint-madrid-2026.yaml
@@ -52,6 +52,9 @@ days:
       - title: Lightning talks (AM)
         start: 2026-05-15 09:00:00
         end: 2026-05-15 09:30:00
+      - title: Session # Terraform
+        start: 2026-05-15 14:00:00
+        end: 2026-05-15 15:00:00
       - title: Lightning talks (PM)
         start: 2026-05-15 15:30:00
         end: 2026-05-15 16:00:00

--- a/events/roadmap-sprint-madrid-2026.yaml
+++ b/events/roadmap-sprint-madrid-2026.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=./event.schema.json
 title: Product Roadmap Sprint
 subtitle: Madrid, May 2026
+live_stream_url: https://stream.meet.google.com/stream/4f77e620-f41c-4ab9-beb2-29aa1c79dfd2
 all_videos_url: /videos?event=roadmap-sprint&date=q2-2026
 days:
   - date: 2026-05-04

--- a/events/roadmap-sprint-madrid-2026.yaml
+++ b/events/roadmap-sprint-madrid-2026.yaml
@@ -1,0 +1,83 @@
+# yaml-language-server: $schema=./event.schema.json
+title: Product Roadmap Sprint
+subtitle: Madrid, May 2026
+all_videos_url: /videos?event=roadmap-sprint&date=q2-2026
+days:
+  - date: 2026-05-04
+    title: Monday, May 4
+    sessions:
+      - title: Plenary
+        start: 2026-05-04 08:30:00
+        end: 2026-05-04 09:30:00
+      - title: Roadmap
+        start: 2026-05-04 16:00:00
+        end: 2026-05-04 17:00:00
+      - title: Lightning talks
+        start: 2026-05-04 17:00:00
+        end: 2026-05-04 17:30:00
+  - date: 2026-05-05
+    title: Tuesday, May 5
+    sessions:
+      - title: Roadmap
+        start: 2026-05-05 08:30:00
+        end: 2026-05-05 09:15:00
+      - title: Roadmap
+        start: 2026-05-05 09:15:00
+        end: 2026-05-05 09:45:00
+      - title: Roadmap
+        start: 2026-05-05 16:00:00
+        end: 2026-05-05 16:45:00
+      - title: Roadmap
+        start: 2026-05-05 16:45:00
+        end: 2026-05-05 17:00:00
+      - title: Lightning talks
+        start: 2026-05-05 17:00:00
+        end: 2026-05-05 17:30:00
+  - date: 2026-05-06
+    title: Wednesday, May 6
+    sessions:
+      - title: Roadmap
+        start: 2026-05-06 08:30:00
+        end: 2026-05-06 09:15:00
+      - title: Roadmap
+        start: 2026-05-06 09:15:00
+        end: 2026-05-06 10:00:00
+      - title: Roadmap
+        start: 2026-05-06 16:00:00
+        end: 2026-05-06 17:00:00
+      - title: Lightning talks
+        start: 2026-05-06 17:00:00
+        end: 2026-05-06 17:30:00
+  - date: 2026-05-07
+    title: Thursday, May 7
+    sessions:
+      - title: Roadmap
+        start: 2026-05-07 08:30:00
+        end: 2026-05-07 09:15:00
+      - title: Roadmap
+        start: 2026-05-07 09:15:00
+        end: 2026-05-07 10:00:00
+      - title: Roadmap
+        start: 2026-05-07 16:00:00
+        end: 2026-05-07 16:30:00
+      - title: Roadmap
+        start: 2026-05-07 16:30:00
+        end: 2026-05-07 17:00:00
+      - title: Lightning talks
+        start: 2026-05-07 17:00:00
+        end: 2026-05-07 17:30:00
+  - date: 2026-05-08
+    title: Friday, May 8
+    sessions:
+      - title: Roadmap
+        start: 2026-05-08 08:30:00
+        end: 2026-05-08 09:15:00
+      - title: Roadmap
+        start: 2026-05-08 09:15:00
+        end: 2026-05-08 10:00:00
+      - title: Lightning talks
+        start: 2026-05-08 15:00:00
+        end: 2026-05-08 15:30:00
+      - title: Closing plenary
+        start: 2026-05-08 15:30:00
+        end: 2026-05-08 16:00:00

--- a/events/roadmap-sprint-madrid-2026.yaml
+++ b/events/roadmap-sprint-madrid-2026.yaml
@@ -10,7 +10,7 @@ days:
       - title: Plenary
         start: 2026-05-04 08:30:00
         end: 2026-05-04 09:30:00
-      - title: Roadmap
+      - title: Roadmap # Excellence
         start: 2026-05-04 16:00:00
         end: 2026-05-04 17:00:00
       - title: Lightning talks
@@ -19,16 +19,19 @@ days:
   - date: 2026-05-05
     title: Tuesday, May 5
     sessions:
-      - title: Roadmap
+      - title: Roadmap # Design
         start: 2026-05-05 08:30:00
         end: 2026-05-05 09:15:00
-      - title: Roadmap
+      - title: Roadmap # IS
         start: 2026-05-05 09:15:00
         end: 2026-05-05 09:45:00
-      - title: Roadmap
+      - title: Open session # AI in Workplace
+        start: 2026-05-05 11:45:00
+        end: 2026-05-05 12:30:00
+      - title: Roadmap # Documentation
         start: 2026-05-05 16:00:00
         end: 2026-05-05 16:45:00
-      - title: Roadmap
+      - title: Roadmap # SecOps
         start: 2026-05-05 16:45:00
         end: 2026-05-05 17:00:00
       - title: Lightning talks
@@ -37,13 +40,13 @@ days:
   - date: 2026-05-06
     title: Wednesday, May 6
     sessions:
-      - title: Roadmap
+      - title: Session # Product Strategy
         start: 2026-05-06 08:30:00
         end: 2026-05-06 09:15:00
-      - title: Roadmap
+      - title: Roadmap # Charmed
         start: 2026-05-06 09:15:00
         end: 2026-05-06 10:00:00
-      - title: Roadmap
+      - title: Roadmap # Cloud
         start: 2026-05-06 16:00:00
         end: 2026-05-06 17:00:00
       - title: Lightning talks
@@ -52,16 +55,19 @@ days:
   - date: 2026-05-07
     title: Thursday, May 7
     sessions:
-      - title: Roadmap
+      - title: Roadmap # SAAS
         start: 2026-05-07 08:30:00
         end: 2026-05-07 09:15:00
-      - title: Roadmap
+      - title: Roadmap # Commercial Systems
         start: 2026-05-07 09:15:00
         end: 2026-05-07 10:00:00
-      - title: Roadmap
+      - title: Open session # JIRA
+        start: 2026-05-07 11:00:00
+        end: 2026-05-07 12:30:00
+      - title: Roadmap # Devices
         start: 2026-05-07 16:00:00
         end: 2026-05-07 16:30:00
-      - title: Roadmap
+      - title: Roadmap # Public Cloud, Silicon, Kernel
         start: 2026-05-07 16:30:00
         end: 2026-05-07 17:00:00
       - title: Lightning talks
@@ -70,10 +76,10 @@ days:
   - date: 2026-05-08
     title: Friday, May 8
     sessions:
-      - title: Roadmap
+      - title: Roadmap # Web
         start: 2026-05-08 08:30:00
         end: 2026-05-08 09:15:00
-      - title: Roadmap
+      - title: Roadmap # Ubuntu Engineering
         start: 2026-05-08 09:15:00
         end: 2026-05-08 10:00:00
       - title: Lightning talks

--- a/templates/base.html
+++ b/templates/base.html
@@ -45,6 +45,12 @@
               <a href="#sprints-toggle-menu" aria-controls="sprints-toggle-menu" class="p-navigation__link">Sprints</a>
               <ul class="p-navigation__dropdown" id="sprints-toggle-menu" aria-hidden="true">
                 <li>
+                  <a href="/events/engineering-sprint-madrid-2026" class="p-navigation__dropdown-item">Engineering Sprint Madrid 2026</a>
+                </li>
+                <li>
+                  <a href="/events/roadmap-sprint-madrid-2026" class="p-navigation__dropdown-item">Roadmap Sprint Madrid 2026</a>
+                </li>
+                <li>
                   <a href="/events/commercial-sprint-vienna-2026" class="p-navigation__dropdown-item">Commercial Sprint Vienna 2026</a>
                 </li>
                 <li>

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -41,6 +41,42 @@
 </div>
 {% endif %}
 
+{# hide main Madrid hero after the sprint has ended #}
+{% set madrid_end_unixtime = 1778889600 %} {# 2026-05-16T00:00:00Z #}
+{% if now < madrid_end_unixtime %}
+{% call(slot) vf_hero(
+  title_text='Madrid Sprints',
+  subtitle_text='May 2026',
+  layout='50/50'
+) -%}
+{%- if slot == 'description' -%}
+<p>
+  We are kicking off the 26.10 cycle in Madrid with Product Roadmap and Engineering Sprints.
+  Join live sessions, or watch the recordings later in our Masterclass video library.
+</p>
+{%- endif -%}
+{%- if slot == 'cta' -%}
+<a href="https://stream.meet.google.com/stream/4f77e620-f41c-4ab9-beb2-29aa1c79dfd2" class="p-button--positive">Join the live stream</a>
+<a href="/events/roadmap-sprint-madrid-2026" class="p-button">Roadmap Sprint</a>
+<a href="/events/engineering-sprint-madrid-2026" class="p-button">Engineering Sprint</a>
+{%- endif -%}
+{%- if slot == 'image' -%}
+<div class="u-hide--medium u-hide--small">
+  <div class="p-image-container--3-2 is-cover">
+    <img loading="auto" alt="Madrid city placeholder image"
+      src="https://upload.wikimedia.org/wikipedia/commons/1/14/Madrid_-_Sky_Bar_360%C2%BA_%28Hotel_Riu_Plaza_Espa%C3%B1a%29%2C_vistas_19.jpg"
+      class="p-image-container__image">
+  </div>
+  <p class="u-text--muted u-text--small"><small>Copyright: <a href="https://commons.wikimedia.org/wiki/File:Madrid_-_Sky_Bar_360%C2%BA_(Hotel_Riu_Plaza_Espa%C3%B1a),_vistas_19.jpg">CC0 1.0 Universal Public Domain Dedication</a></small></p>
+</div>
+{%- endif -%}
+{% endcall -%}
+
+<div class="u-fixed-width">
+  <hr class="p-rule" />
+</div>
+{% endif %}
+
 {% call(slot) vf_hero(
   title_text='Masterclass',
   subtitle_text='Your one-stop video library for Canonical talks',


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site at demos https://masterclasses-canonical-com-101.demos.haus/
- Sign in with your canonical SSO
- Make sure home page features Madrid sprints
- Make sure Events droprown features Madrid sprints
- Make sure both Roadmap and Engineering sprint pages list the schedule (no videos in demo data)

## Screenshots

<img width="1432" height="629" alt="image" src="https://github.com/user-attachments/assets/df9caa7a-8201-4260-b079-04e8fe2296bb" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
